### PR TITLE
GNOME runtime 41, FEDC support

### DIFF
--- a/org.gnome.SoundRecorder.json
+++ b/org.gnome.SoundRecorder.json
@@ -1,10 +1,10 @@
 {
-    "app-id" : "org.gnome.SoundRecorder",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "41",
-    "sdk" : "org.gnome.Sdk",
-    "command" : "gnome-sound-recorder",
-    "finish-args" : [
+    "app-id": "org.gnome.SoundRecorder",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "41",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-sound-recorder",
+    "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
@@ -12,15 +12,19 @@
         "--filesystem=~/Recordings",
         "--metadata=X-DConf=migrate-path=/org/gnome/SoundRecorder/"
     ],
-    "modules" : [
+    "modules": [
         {
-            "name" : "gnome-sound-recorder",
-            "buildsystem" : "meson",
-            "sources" : [
+            "name": "gnome-sound-recorder",
+            "buildsystem": "meson",
+            "sources": [
                 {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gnome-sound-recorder/40/gnome-sound-recorder-40.0.tar.xz",
-                    "sha256": "d4aa4c104d7465dd15807bf1703e65ff682eff52841c59cf3a07f5eff42e6501"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-sound-recorder/40/gnome-sound-recorder-40.0.tar.xz",
+                    "sha256": "d4aa4c104d7465dd15807bf1703e65ff682eff52841c59cf3a07f5eff42e6501",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnome-sound-recorder"
+                    }
                 }
             ]
         }

--- a/org.gnome.SoundRecorder.json
+++ b/org.gnome.SoundRecorder.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.SoundRecorder",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-sound-recorder",
     "finish-args" : [


### PR DESCRIPTION
Updated GNOME runtime to 41, added FEDC support.